### PR TITLE
create release from gh action on push to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,6 @@ on:
     push:
         branches:
             - main
-
 permissions:
     contents: write
 
@@ -36,9 +35,6 @@ jobs:
               if: startsWith(github.ref, 'refs/tags/')
               with:
                   files: |
-                      extension/chrome
-                      extension/firefox
-                      extension/opera
                       extension/chrome.zip
                       extension/firefox.xpi
                       extension/opera.crx

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,44 @@
+name: 'Build And Create New Release'
+
+on:
+    push:
+        branches:
+            - main
+
+permissions:
+    contents: write
+
+jobs:
+    release:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v3
+            - name: Install NodeJs v14
+              uses: actions/setup-node@v3
+              with:
+                  # Version Spec of the version to use in SemVer notation.
+                  # It also emits such aliases as lts, latest, nightly and canary builds
+                  # Examples: 12.x, 10.15.1, >=10.15.0, lts/Hydrogen, 16-nightly, latest, node
+                  node-version: '14.x'
+
+            - name: Run Install
+              uses: borales/actions-yarn@v4
+              with:
+                  cmd: install
+            - name: Build production bundle
+              uses: borales/actions-yarn@v4
+              with:
+                  cmd: build # will run `yarn build` command
+
+            - name: Release
+              uses: softprops/action-gh-release@v1
+              if: startsWith(github.ref, 'refs/tags/')
+              with:
+                  files: |
+                      extension/chrome
+                      extension/firefox
+                      extension/opera
+                      extension/chrome.zip
+                      extension/firefox.xpi
+                      extension/opera.crx

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ Experiencing a situation where your country inexplicably blocks certain content 
 
 ## Installation
 
+- from releases download the package to your browser `chrome.zip`, `firefox.xpi` or `opera.crx`
+
+- in chrome goto `chrome://extensions/` and enable developer mode, then drag drop the `chrome.zip` file
+
+- if you want to load from source check [Contributing](#contributing)
+
 ## Contributing
 
 - make sure you have node.js v14 `nvm use 14`

--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
 # alt-cdn
+
 Experiencing a situation where your country inexplicably blocks certain content delivery networks, like jsDelivr, can be quite frustrating. This leads to numerous broken websites due to missing essential JavaScript files. This extension provides an alternative to using a VPN. It simply asks for a list of preferred providers (usually just one for most people) and automatically replaces the blocked content with suitable alternatives.
+
+## Installation
+
+## Contributing
+
+- make sure you have node.js v14 `nvm use 14`
+
+- install yarn `npm i -g yarn`
+
+- install `yarn install`
+
+- run dev command for your browser `yarn dev:chome` or `yarn dev:firefox` or `yarn dev:opera`
+
+- add the extension to your browser
+  - In Chrome/Edge 
+        1. go to the extensions page (`chrome://extensions` or `edge://extensions`).
+        2. Enable Developer Mode.
+        3. click `load unpacked` then select `$your-project-path/extension/chrome`

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,196 +18,207 @@ const nodeEnv = process.env.NODE_ENV || 'development';
 const targetBrowser = process.env.TARGET_BROWSER;
 
 const extensionReloaderPlugin =
-  nodeEnv === 'development'
-    ? new ExtensionReloader({
-      port: 9090,
-      reloadPage: true,
-      entries: {
-        // TODO: reload manifest on update
-        contentScript: 'contentScript',
-        background: 'background',
-        extensionPage: ['popup', 'options'],
-      },
-    })
-    : () => {
-      this.apply = () => { };
-    };
+    nodeEnv === 'development'
+        ? new ExtensionReloader({
+              port: 9090,
+              reloadPage: true,
+              entries: {
+                  // TODO: reload manifest on update
+                  contentScript: 'contentScript',
+                  background: 'background',
+                  extensionPage: ['popup', 'options'],
+              },
+          })
+        : () => {
+              this.apply = () => {};
+          };
 
 const getExtensionFileType = (browser) => {
-  if (browser === 'opera') {
-    return 'crx';
-  }
+    if (browser === 'opera') {
+        return 'crx';
+    }
 
-  if (browser === 'firefox') {
-    return 'xpi';
-  }
+    if (browser === 'firefox') {
+        return 'xpi';
+    }
 
-  return 'zip';
+    return 'zip';
 };
 
 module.exports = {
-  devtool: false, // https://github.com/webpack/webpack/issues/1194#issuecomment-560382342
+    devtool: false, // https://github.com/webpack/webpack/issues/1194#issuecomment-560382342
 
-  stats: {
-    all: false,
-    builtAt: true,
-    errors: true,
-    hash: true,
-  },
-
-  mode: nodeEnv,
-
-  entry: {
-    manifest: path.join(sourcePath, 'manifest.json'),
-    background: path.join(sourcePath, 'Background', 'index.ts'),
-    contentScript: path.join(sourcePath, 'ContentScript', 'index.ts'),
-    popup: path.join(sourcePath, 'Popup', 'index.tsx'),
-    options: path.join(sourcePath, 'Options', 'index.tsx'),
-  },
-
-  output: {
-    path: path.join(destPath, targetBrowser),
-    filename: 'js/[name].bundle.js',
-  },
-
-  resolve: {
-    extensions: ['.ts', '.tsx', '.js', '.json'],
-    alias: {
-      'webextension-polyfill-ts': path.resolve(
-        path.join(__dirname, 'node_modules', 'webextension-polyfill-ts')
-      ),
+    stats: {
+        all: false,
+        builtAt: true,
+        errors: true,
+        hash: true,
     },
-  },
 
-  module: {
-    rules: [
-      {
-        type: 'javascript/auto', // prevent webpack handling json with its own loaders,
-        test: /manifest\.json$/,
-        use: {
-          loader: 'wext-manifest-loader',
-          options: {
-            usePackageJSONVersion: true, // set to false to not use package.json version for manifest
-          },
+    mode: nodeEnv,
+
+    entry: {
+        manifest: path.join(sourcePath, 'manifest.json'),
+        background: path.join(sourcePath, 'Background', 'index.ts'),
+        contentScript: path.join(sourcePath, 'ContentScript', 'index.ts'),
+        popup: path.join(sourcePath, 'Popup', 'index.tsx'),
+        options: path.join(sourcePath, 'Options', 'index.tsx'),
+    },
+
+    output: {
+        path: path.join(destPath, targetBrowser),
+        filename: 'js/[name].bundle.js',
+    },
+
+    resolve: {
+        extensions: ['.ts', '.tsx', '.js', '.json'],
+        alias: {
+            'webextension-polyfill-ts': path.resolve(
+                path.join(
+                    __dirname,
+                    'node_modules',
+                    'webextension-polyfill-ts',
+                ),
+            ),
         },
-        exclude: /node_modules/,
-      },
-      {
-        test: /\.(js|ts)x?$/,
-        loader: 'babel-loader',
-        exclude: /node_modules/,
-      },
-      {
-        test: /\.(sa|sc|c)ss$/,
-        use: [
-          {
-            loader: MiniCssExtractPlugin.loader, // It creates a CSS file per JS file which contains CSS
-          },
-          {
-            loader: 'css-loader', // Takes the CSS files and returns the CSS with imports and url(...) for Webpack
-            options: {
-              sourceMap: true,
-            },
-          },
-          {
-            loader: 'postcss-loader',
-            options: {
-              postcssOptions: {
-                plugins: [
-                  [
-                    'autoprefixer',
+    },
 
-                    {
-                      // Options
+    module: {
+        rules: [
+            {
+                type: 'javascript/auto', // prevent webpack handling json with its own loaders,
+                test: /manifest\.json$/,
+                use: {
+                    loader: 'wext-manifest-loader',
+                    options: {
+                        usePackageJSONVersion: true, // set to false to not use package.json version for manifest
                     },
-                  ],
-                  tailwindcss('./tailwind.config.js'),
-                ],
-              },
+                },
+                exclude: /node_modules/,
             },
-          },
-          'resolve-url-loader', // Rewrites relative paths in url() statements
+            {
+                test: /\.(js|ts)x?$/,
+                loader: 'babel-loader',
+                exclude: /node_modules/,
+            },
+            {
+                test: /\.(sa|sc|c)ss$/,
+                use: [
+                    {
+                        loader: MiniCssExtractPlugin.loader, // It creates a CSS file per JS file which contains CSS
+                    },
+                    {
+                        loader: 'css-loader', // Takes the CSS files and returns the CSS with imports and url(...) for Webpack
+                        options: {
+                            sourceMap: true,
+                        },
+                    },
+                    {
+                        loader: 'postcss-loader',
+                        options: {
+                            postcssOptions: {
+                                plugins: [
+                                    [
+                                        'autoprefixer',
 
+                                        {
+                                            // Options
+                                        },
+                                    ],
+                                    tailwindcss('./tailwind.config.js'),
+                                ],
+                            },
+                        },
+                    },
+                    'resolve-url-loader', // Rewrites relative paths in url() statements
+                ],
+            },
         ],
-      },
-    ],
-  },
+    },
 
-  plugins: [
-    // Plugin to not generate js bundle for manifest entry
-    new WextManifestWebpackPlugin(),
-    // Generate sourcemaps
-    new webpack.SourceMapDevToolPlugin({ filename: false }),
-    new ForkTsCheckerWebpackPlugin(),
-    // environmental variables
-    new webpack.EnvironmentPlugin(['NODE_ENV', 'TARGET_BROWSER']),
-    // delete previous build files
-    new CleanWebpackPlugin({
-      cleanOnceBeforeBuildPatterns: [
-        path.join(process.cwd(), `extension/${targetBrowser}`),
-        path.join(
-          process.cwd(),
-          `extension/${targetBrowser}.${getExtensionFileType(targetBrowser)}`
-        ),
-      ],
-      cleanStaleWebpackAssets: false,
-      verbose: true,
-    }),
-    new HtmlWebpackPlugin({
-      template: path.join(viewsPath, 'popup.html'),
-      inject: 'body',
-      chunks: ['popup'],
-      hash: true,
-      filename: 'popup.html',
-    }),
-    new HtmlWebpackPlugin({
-      template: path.join(viewsPath, 'options.html'),
-      inject: 'body',
-      chunks: ['options'],
-      hash: true,
-      filename: 'options.html',
-    }),
-    // write css file(s) to build folder
-    new MiniCssExtractPlugin({ filename: 'css/[name].css' }),
-    // copy static assets
-    new CopyWebpackPlugin({
-      patterns: [{ from: 'source/assets', to: 'assets' }],
-    }),
-    // plugin to enable browser reloading in development mode
-    extensionReloaderPlugin,
-  ],
-
-  optimization: {
-    minimize: true,
-    minimizer: [
-      new TerserPlugin({
-        parallel: true,
-        terserOptions: {
-          format: {
-            comments: false,
-          },
-        },
-        extractComments: false,
-      }),
-      new OptimizeCSSAssetsPlugin({
-        cssProcessorPluginOptions: {
-          preset: ['default', { discardComments: { removeAll: true } }],
-        },
-      }),
-      new FilemanagerPlugin({
-        events: {
-          onEnd: {
-            archive: [
-              {
-                format: 'zip',
-                source: path.join(destPath, targetBrowser),
-                destination: `${path.join(destPath, targetBrowser)}.${getExtensionFileType(targetBrowser)}`,
-                options: { zlib: { level: 6 } },
-              },
+    plugins: [
+        // Plugin to not generate js bundle for manifest entry
+        new WextManifestWebpackPlugin(),
+        // Generate sourcemaps
+        new webpack.SourceMapDevToolPlugin({ filename: false }),
+        new ForkTsCheckerWebpackPlugin(),
+        // environmental variables
+        new webpack.EnvironmentPlugin(['NODE_ENV', 'TARGET_BROWSER']),
+        // delete previous build files
+        new CleanWebpackPlugin({
+            cleanOnceBeforeBuildPatterns: [
+                path.join(process.cwd(), `extension/${targetBrowser}`),
+                path.join(
+                    process.cwd(),
+                    `extension/${targetBrowser}.${getExtensionFileType(
+                        targetBrowser,
+                    )}`,
+                ),
             ],
-          },
-        },
-      }),
+            cleanStaleWebpackAssets: false,
+            verbose: true,
+        }),
+        new HtmlWebpackPlugin({
+            template: path.join(viewsPath, 'popup.html'),
+            inject: 'body',
+            chunks: ['popup'],
+            hash: true,
+            filename: 'popup.html',
+        }),
+        new HtmlWebpackPlugin({
+            template: path.join(viewsPath, 'options.html'),
+            inject: 'body',
+            chunks: ['options'],
+            hash: true,
+            filename: 'options.html',
+        }),
+        // write css file(s) to build folder
+        new MiniCssExtractPlugin({ filename: 'css/[name].css' }),
+        // copy static assets
+        new CopyWebpackPlugin({
+            patterns: [{ from: 'source/assets', to: 'assets' }],
+        }),
+        // plugin to enable browser reloading in development mode
+        extensionReloaderPlugin,
     ],
-  },
+
+    optimization: {
+        minimize: true,
+        minimizer: [
+            new TerserPlugin({
+                parallel: true,
+                terserOptions: {
+                    format: {
+                        comments: false,
+                    },
+                },
+                extractComments: false,
+            }),
+            new OptimizeCSSAssetsPlugin({
+                cssProcessorPluginOptions: {
+                    preset: [
+                        'default',
+                        { discardComments: { removeAll: true } },
+                    ],
+                },
+            }),
+            new FilemanagerPlugin({
+                events: {
+                    onEnd: {
+                        archive: [
+                            {
+                                format: 'zip',
+                                source: path.join(destPath, targetBrowser),
+                                destination: `${path.join(
+                                    destPath,
+                                    targetBrowser,
+                                )}.${getExtensionFileType(targetBrowser)}`,
+                                options: { zlib: { level: 6 } },
+                            },
+                        ],
+                    },
+                },
+            }),
+        ],
+    },
 };


### PR DESCRIPTION
idk if creating tag manually is a good DX but the current action requires using `git tag` and push the tags to github `git push origin --tags` to use this tag as the release name 

for example to create release v1

```bash
git tag -a v1 -m "intial release2"
git push origin --tags
```

> NOTE: if you pushed to main without creating tag first won't create release, but after that if you created release will re-run the action automatic no need to push dummy commits to trigger release 

the action add the following as assets with the release
 - `extension/chrome.zip`
- `extension/firefox.xpi`
-  `extension/opera.crx`